### PR TITLE
No need to run clippy and rustfmt on pushes to non-main branches.

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 name: Clippy check
 jobs:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 name: Code formatting check
 


### PR DESCRIPTION
They get run for pull requests anyway, running on push results in duplicate runs.