### PR TITLE
Update to gd32f1 0.4.0 and prepare for 0.5.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.0]
+
+### Breaking changes
+
+- Updated to `gd32f1` 0.4.0, which fixes a bug which prevented all timers apart from TIMER0 from
+  working properly.
+
 ## [0.4.0]
 
 ### Breaking changes
@@ -42,8 +49,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 First release.
 
-[unreleased]: https://github.com/qwandor/gd32f1x0-hal/compare/0.4.0...HEAD
+[unreleased]: https://github.com/qwandor/gd32f1x0-hal/compare/0.5.0...HEAD
 [0.2.0]: https://github.com/qwandor/gd32f1x0-hal/compare/0.1.0...0.2.0
 [0.2.1]: https://github.com/qwandor/gd32f1x0-hal/compare/0.2.0...0.2.1
 [0.3.0]: https://github.com/qwandor/gd32f1x0-hal/compare/0.2.1...0.3.0
 [0.4.0]: https://github.com/qwandor/gd32f1x0-hal/compare/0.3.0...0.4.0
+[0.5.0]: https://github.com/qwandor/gd32f1x0-hal/compare/0.4.0...0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/qwandor/gd32f1x0-hal"
 documentation = "https://docs.rs/gd2f1x0-hal"
 readme = "README.md"
 edition = "2018"
-version = "0.4.0"
+version = "0.5.0"
 
 [package.metadata.docs.rs]
 features = ["gd32f130x8", "rt"]
@@ -22,7 +22,7 @@ cortex-m = "0.7.2"
 cortex-m-rt = "0.6.13"
 embedded-dma = "0.1.2"
 embedded-hal = { version = "0.2.5", features = ["unproven"] }
-gd32f1 = "0.3.0"
+gd32f1 = "0.4.0"
 nb = "1.0.0"
 void = { version = "1.0.2", default-features = false }
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cortex-m = "0.7.2"
 cortex-m-rt = "0.6.13"
 # Panic behaviour, see https://crates.io/keywords/panic-impl for alternatives
 panic-halt = "0.2.0"
-gd32f1x0-hal = { version = "0.4.0", features = ["rt", "gd32f130x8"] }
+gd32f1x0-hal = { version = "0.5.0", features = ["rt", "gd32f130x8"] }
 ```
 
 If you build your project now, you should get a single error:
@@ -162,7 +162,7 @@ When using this crate as a dependency in your project, the microcontroller can
 be specified as part of the `Cargo.toml` definition.
 
 ```toml
-gd32f1x0-hal = { version = "0.4.0", features = ["gd32f130x8", "rt"] }
+gd32f1x0-hal = { version = "0.5.0", features = ["gd32f130x8", "rt"] }
 ```
 
 ## Documentation


### PR DESCRIPTION
This fixes a bug with timers (including PWM).

See https://github.com/qwandor/gd32-rs/pull/18 for details of the bugfix.